### PR TITLE
Admit version ^3 of doctrine/common composer package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "description": "Workarround to the issues related of using Doctrine with embedabbles relations where the relation can be null. If the object is null doctrine would instanciate it with all the properties to null, this library will fix it to set it to null.",
     "require": {
         "php": "^7.1",
-        "doctrine/common": "^2",
+        "doctrine/common": "^2 || ^3",
         "symfony/yaml": ">= 4.0",
         "symfony/finder": ">= 4.0",
         "doctrine/orm": "^2"


### PR DESCRIPTION
- Add version ^3 of doctrine/common dependency to allow other projects that use this library use it with the version 3 of the doctrine/common package.